### PR TITLE
Expanded Error codes, Added Mono warning, and created a working version of Set Votelist

### DIFF
--- a/VndbSharp/Structs/Models/OmniError.cs
+++ b/VndbSharp/Structs/Models/OmniError.cs
@@ -12,5 +12,13 @@ namespace VndbSharp.Structs.Models
 		[JsonProperty("msg")]
 		public String Message;
 
-	}
+	    [JsonProperty("type")]
+        public String Type;
+
+        [JsonProperty("minwait")]
+        public Double? MinimumWait;
+
+        [JsonProperty("fullwait")]
+        public Double? MaximumWait;
+    }
 }

--- a/VndbSharp/VndbClient.cs
+++ b/VndbSharp/VndbClient.cs
@@ -51,7 +51,9 @@ namespace VndbSharp
 		protected String Username;
 		protected SecureString Password;
 
-		public Int32 ReceiveBufferSize
+        internal static Boolean HasMono { get; } = Type.GetType("Mono.Runtime") != null;
+
+        public Int32 ReceiveBufferSize
 		{
 			get { return this.Client?.ReceiveBufferSize ?? this._receiveBufferSize; }
 			set
@@ -86,8 +88,7 @@ namespace VndbSharp
 			}
 		}
 
-        // TODO: Use HasMono property on TLS to warn about lack of encryption support
-	    internal static Boolean HasMono { get; } = Type.GetType("Mono.Runtime") != null;
+
 
 		public VndbClient()
 		{ }
@@ -105,7 +106,9 @@ namespace VndbSharp
 		/// </summary>
 		public VndbClient(String username, SecureString password)
 		{
-			this.UseTls = true;
+            if(HasMono != true)
+                Console.WriteLine("Mono and .NET Core's SecureString is NOT secure. Please consider an alternative, or warn your users");
+            this.UseTls = true;
 			this.Username = username;
 			this.Password = password;
 		}

--- a/VndbSharp/VndbClient.cs
+++ b/VndbSharp/VndbClient.cs
@@ -327,10 +327,10 @@ namespace VndbSharp
             return null;
         }
 
-	    public async Task SetVoteListAsync(int id, int? vote)
+	    public async Task<Object> SetVoteListAsync(int id, int? vote)
 	    {
 	        if (!await this.LoginAsync().ConfigureAwait(false))
-	            return;
+	            return null;
 	        var data = $"set votelist "+id;
 	        if (vote != null)
 	            data = data + " {\"vote\":" + vote + "}";
@@ -340,11 +340,11 @@ namespace VndbSharp
             var response = await this.GetResponseAsync().ConfigureAwait(false);
 
 
-	        if (response == "ok") return;
+	        if (response == "ok") return "ok";
 	        var results = response.Split(new[] { ' ' }, 2);
 	        Debug.WriteLine(results[1]);
 	        this.SetLastError(results[1]);
-            //not sure if I should have this as a Task<>, and deserialize any error messages, returning them to the client. On Success, response returns "ok
+            return JsonConvert.DeserializeObject<OmniError>(results[1]);
         }
 		public async Task<String> DoRawAsync(String command)
 		{

--- a/VndbSharp/VndbClient.cs
+++ b/VndbSharp/VndbClient.cs
@@ -327,6 +327,25 @@ namespace VndbSharp
             return null;
         }
 
+	    public async Task SetVoteListAsync(int id, int? vote)
+	    {
+	        if (!await this.LoginAsync().ConfigureAwait(false))
+	            return;
+	        var data = $"set votelist "+id;
+	        if (vote != null)
+	            data = data + " {\"vote\":" + vote + "}";
+            Debug.WriteLine(data);
+
+            await this.SendDataAsync(this.FormatRequest(data)).ConfigureAwait(false);
+            var response = await this.GetResponseAsync().ConfigureAwait(false);
+
+
+	        if (response == "ok") return;
+	        var results = response.Split(new[] { ' ' }, 2);
+	        Debug.WriteLine(results[1]);
+	        this.SetLastError(results[1]);
+            //not sure if I should have this as a Task<>, and deserialize any error messages, returning them to the client. On Success, response returns "ok
+        }
 		public async Task<String> DoRawAsync(String command)
 		{
 			try


### PR DESCRIPTION
So I used the "HasMono" to warn programmers about the lack of security while using the SecureString class. 

I also created a sample version of the "set votelist" command. I didn't use the same framework as the previous "get" commands, as the "set" commands have no filter support.

Also, I'm unsure if you wished for the set commands to return an "ok" or an error message after it tries to set something in the API. If you wish for the set commands to return an error or "ok", I'll rework it to include that. I just wanted input before I create the other "set" methods.