### PR TITLE
Added HasMono to warn about lack of encryption.

### DIFF
--- a/VndbSharp/VndbClient.cs
+++ b/VndbSharp/VndbClient.cs
@@ -79,8 +79,6 @@ namespace VndbSharp
 				this.LoggedIn = false;
 			}
 		}
-
-        // TODO: Use HasMono property on TLS to warn about lack of encryption support
 	    internal static Boolean HasMono { get; } = Type.GetType("Mono.Runtime") != null;
 
 		public VndbClient()
@@ -91,14 +89,17 @@ namespace VndbSharp
 			this.UseTls = useTls;
 		}
 
-		/// <summary>
-		///		If using .Net Core or Mono, please read https://github.com/Nikey646/VndbSharp/wiki/Mono-and-.Net-Core#securestring--username--password-logins
-		/// 
-		/// 	This will also *force* a secure connection.
-		/// </summary>
-		public VndbClient(String username, SecureString password)
+        /// <summary>
+        ///		If using .Net Core or Mono, please read https://github.com/Nikey646/VndbSharp/wiki/Mono-and-.Net-Core#securestring--username--password-logins
+        ///     .Net Core seems to have implemented a fix for SecureString, though without encryption support: 
+        ///      https://github.com/dotnet/coreclr/blob/e74cdcb1ed6021eaf03eea5ee7f6ba3c6b403daf/src/mscorlib/corefx/System/Security/SecureString.Unix.cs
+        /// 	This will also *force* a secure connection.
+        /// </summary>
+        public VndbClient(String username, SecureString password)
 		{
-			this.UseTls = true;
+		    if (HasMono ==false)
+		        Console.WriteLine("Mono's SecureString is not secure. Consider warning your users if they are using mono runtime");
+            this.UseTls = true;
 			this.Username = username;
 			this.Password = password;
 		}

--- a/VndbSharp/VndbClient.cs
+++ b/VndbSharp/VndbClient.cs
@@ -97,7 +97,7 @@ namespace VndbSharp
         /// </summary>
         public VndbClient(String username, SecureString password)
 		{
-		    if (HasMono ==false)
+		    if (HasMono)
 		        Console.WriteLine("Mono's SecureString is not secure. Consider warning your users if they are using mono runtime");
             this.UseTls = true;
 			this.Username = username;


### PR DESCRIPTION
.NET core seems to have a better implementation of SecureString though.
https://github.com/dotnet/coreclr/blob/e74cdcb1ed6021eaf03eea5ee7f6ba3c6b403daf/src/mscorlib/corefx/System/Security/SecureString.Unix.cs#L11
Unix can do 2 out of the three SecureString mechanisms, but it can't encrypt the data while not in use.
This really shouldn't matter too much anyway, since the API still needs plaintext passwords.