### PR TITLE
changed IRequestOptions to lower case, so that they would work with the API

### DIFF
--- a/VndbSharp/Interfaces/IRequestOptions.cs
+++ b/VndbSharp/Interfaces/IRequestOptions.cs
@@ -1,29 +1,30 @@
 ﻿using System;
 using Newtonsoft.Json;
+// ReSharper disable InconsistentNaming
 
 namespace VndbSharp.Interfaces
 {
-	/// <summary>
-	///		The Request Options to send along to Vndb with the request
-	/// </summary>
-	public interface IRequestOptions
-	{
-		/// <summary>
-		///		The page to get the result from
-		/// </summary>
-		Int32? Page { get; }
-		/// <summary>
-		///		How many Results to get
-		/// </summary>
-		[JsonProperty("results")]
-		Int32? Count { get; }
-		/// <summary>
-		///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
-		/// </summary> 
-		String Sort { get; }
-		/// <summary>
-		///		Sets if the order of the results be reversed or not.
-		/// </summary>
-		Boolean? Reverse { get; }
-	}
+    /// <summary>
+    ///		The Request Options to send along to Vndb with the request
+    /// </summary>
+    public interface IRequestOptions
+    {
+        /// <summary>
+        ///		The page to get the result from
+        /// </summary>
+        Int32? page { get; }
+        /// <summary>
+        ///		How many Results to get
+        /// </summary>
+        [JsonProperty("results")]
+        Int32? count { get; }
+        /// <summary>
+        ///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
+        /// </summary> 
+        String sort { get; }
+        /// <summary>
+        ///		Sets if the order of the results be reversed or not.
+        /// </summary>
+        Boolean? reverse { get; }
+    }
 }


### PR DESCRIPTION
Currently, if you attempt to use properties with standard naming conventions( like bool **P**roperty { get; set; }), the API will disregard the request, and it will not work.

I contacted Vndb's admin about this, and he confirmed that only lowercase works.