### PR TITLE
Fixed IRequestOptions iisue that prevented it from working

### DIFF
--- a/VndbSharp/Interfaces/IRequestOptions.cs
+++ b/VndbSharp/Interfaces/IRequestOptions.cs
@@ -1,29 +1,30 @@
 ﻿using System;
 using Newtonsoft.Json;
+// ReSharper disable InconsistentNaming
 
 namespace VndbSharp.Interfaces
 {
-	/// <summary>
-	///		The Request Options to send along to Vndb with the request
-	/// </summary>
-	public interface IRequestOptions
-	{
-		/// <summary>
-		///		The page to get the result from
-		/// </summary>
-		Int32? Page { get; }
-		/// <summary>
-		///		How many Results to get
-		/// </summary>
-		[JsonProperty("results")]
-		Int32? Count { get; }
-		/// <summary>
-		///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
-		/// </summary> 
-		String Sort { get; }
-		/// <summary>
-		///		Sets if the order of the results be reversed or not.
-		/// </summary>
-		Boolean? Reverse { get; }
-	}
+    /// <summary>
+    ///		The Request Options to send along to Vndb with the request
+    /// </summary>
+    public interface IRequestOptions
+    {
+        /// <summary>
+        ///		The page to get the result from
+        /// </summary>
+        Int32? page { get; }
+        /// <summary>
+        ///		How many Results to get
+        /// </summary>
+        [JsonProperty("results")]
+        Int32? count { get; }
+        /// <summary>
+        ///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
+        /// </summary> 
+        String sort { get; }
+        /// <summary>
+        ///		Sets if the order of the results be reversed or not.
+        /// </summary>
+        Boolean? reverse { get; }
+    }
 }

--- a/VndbSharp/Interfaces/IRequestOptions.cs
+++ b/VndbSharp/Interfaces/IRequestOptions.cs
@@ -1,30 +1,32 @@
 ﻿using System;
 using Newtonsoft.Json;
-// ReSharper disable InconsistentNaming
 
 namespace VndbSharp.Interfaces
 {
-    /// <summary>
-    ///		The Request Options to send along to Vndb with the request
-    /// </summary>
-    public interface IRequestOptions
-    {
-        /// <summary>
-        ///		The page to get the result from
-        /// </summary>
-        Int32? page { get; }
-        /// <summary>
-        ///		How many Results to get
-        /// </summary>
-        [JsonProperty("results")]
-        Int32? count { get; }
-        /// <summary>
-        ///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
-        /// </summary> 
-        String sort { get; }
-        /// <summary>
-        ///		Sets if the order of the results be reversed or not.
-        /// </summary>
-        Boolean? reverse { get; }
-    }
+	/// <summary>
+	///		The Request Options to send along to Vndb with the request
+	/// </summary>
+	public interface IRequestOptions
+	{
+	    /// <summary>
+	    ///		The page to get the result from
+	    /// </summary>
+	    [JsonProperty("page")]
+	    Int32? Page { get; }
+	    /// <summary>
+	    ///		How many Results to get
+	    /// </summary>
+	    [JsonProperty("results")]
+	    Int32? Count { get; }
+	    /// <summary>
+	    ///		 The field to order the results by. The accepted field names differ per type, the default sort field is the ID of the database entry.
+	    /// </summary> 
+	    [JsonProperty("sort")]
+	    String Sort { get; }
+	    /// <summary>
+	    ///		Sets if the order of the results be reversed or not.
+	    /// </summary>
+	    [JsonProperty("reverse")]
+	    Boolean? Reverse { get; }
+	}
 }


### PR DESCRIPTION
I set a [JsonProperty] on the 4 properties so it would send the lowercase name, and not the standard Pascal method that is a C# standard. This should allow the options to properly go through, while adhering to C# standards.