### PR TITLE
Fixed a bug I overlooked that made gettings vns from staff return null.

### DIFF
--- a/VndbSharp/VndbUtils.cs
+++ b/VndbSharp/VndbUtils.cs
@@ -133,11 +133,26 @@ namespace VndbSharp
 				if (identity == null)
 					continue;
 
-				if (!(method == Constants.GetCharacterCommand && (VndbFlags) value == VndbFlags.VisualNovels))
-					yield return identity.Identity;
-				else if(!(method == Constants.GetStaffCommand && (VndbFlags)value == VndbFlags.VisualNovels))
-				    yield return identity.Identity;
-				else yield return $"{identity.Identity}s"; // Ugly hack to work around *two* vn(s) flags
+			    // Ugly hack to work around *two* vn(s) flags
+				if ((VndbFlags)value == VndbFlags.VisualNovels)
+			    {
+			        switch (method)
+			        {
+			            case Constants.GetCharacterCommand:
+			                yield return $"{identity.Identity}s";
+			                break;
+			            case Constants.GetStaffCommand:
+			                yield return $"{identity.Identity}s";
+			                break;
+			            default:
+			                yield return identity.Identity;
+			                break;
+			        }
+			    }
+			    else
+			    {
+			        yield return identity.Identity;
+			    }
 			}
 		}
 


### PR DESCRIPTION
Somehow missed this bug where the get staff command with VndbFlags.VisualNovels would end up sending "get staff vn vns ...", making it return null, since vn isn't a valid request for "get staff".

I probably could have done it in less lines, but I'll work on that later™.