### PR TITLE
Fixed a bug where a null Anime ID would cause a crash

### DIFF
--- a/VndbSharp/Models/VisualNovel/AnimeMetadata.cs
+++ b/VndbSharp/Models/VisualNovel/AnimeMetadata.cs
@@ -7,9 +7,9 @@ namespace VndbSharp.Models.VisualNovel
 	public class AnimeMetadata
 	{
 		[JsonProperty("id")]
-		public Int32 AniDbId { get; private set; }
+		public Int32? AniDbId { get; private set; }
 		[JsonProperty("ann_id")]
-		public Int32 AnimeNewsNetworkId { get; private set; }
+		public Int32? AnimeNewsNetworkId { get; private set; }
 		[JsonProperty("nfo_id")]
 		public String AnimeNfoId { get; private set; }
 		[JsonProperty("title_romaji")]


### PR DESCRIPTION
If ANN or AniDb is null, it would cause a crash when the Json Converter couldn't convert the null to a value.