### PR TITLE
Changed 'vid' filter to 'vn' because of a mistake in the API docs.

### DIFF
--- a/VndbSharp/VndbFilters.cs
+++ b/VndbSharp/VndbFilters.cs
@@ -356,7 +356,7 @@ namespace VndbSharp
 				FilterOperator.GreaterOrEqual, FilterOperator.GreaterThan
 			};
 
-			protected override String FilterName { get; } = "vid";
+			protected override String FilterName { get; } = "vn";
 
 			public static VisualNovelId Equals(params UInt32[] value) => new VisualNovelId(value, FilterOperator.Equal);
 			public static VisualNovelId NotEquals(params UInt32[] value) => new VisualNovelId(value, FilterOperator.NotEqual);


### PR DESCRIPTION
Yorhel made a mistake in the API doc, stating the filter name was 'vid' instead of 'vn'
This fixes that issue.