### PR TITLE
Update VndbFilters.cs - Raw-Filter

### DIFF
--- a/VndbSharp/VndbFilters.cs
+++ b/VndbSharp/VndbFilters.cs
@@ -373,5 +373,31 @@ namespace VndbSharp
 			public override Boolean IsFilterValid()
 				=> this.ValidOperators.Contains(this.Operator);
 		}
+
+		public class Raw : AbstractFilter<String>
+		{
+			private Raw(String value, FilterOperator filterOperator)
+				: base(value, filterOperator)
+			{
+				CanBeNull = true;
+			}
+
+			// This being blank should be fine, since we won't be using it.
+			protected override FilterOperator[] ValidOperators { get; } = { };
+
+			protected override String FilterName { get; } = "null";
+
+			public static Raw Create(String name, String value, FilterOperator filterOperator)
+			{
+				return new Raw(value, filterOperator)
+				{
+					FilterName = name,
+				};
+			}
+
+			// This is a filter we will rely on vndb yelling at us about.
+			public override Boolean IsFilterValid() 
+				=> true;
+		}
 	}
 }


### PR DESCRIPTION
Added the Raw filter which allows providing the raw name and value, is always valid as far as VndbSharp is concerned, which means it doesn't try to validate the operator for the filter.

The reason this filter was added, was while fixing #42, i realized that it's not possible for the filters i've made to handle every single scenario so providing the end user the ability to resort to manually providing filters is the next best option. Of course, i could have just left it out, since the `AbstractFilter<T>` class does all the heavy lifting of creating a filter.... But why not?