### PR TITLE
User auth

### DIFF
--- a/VndbConsoleCore/Program.cs
+++ b/VndbConsoleCore/Program.cs
@@ -51,7 +51,9 @@ namespace VndbConsole
 
 			this._client.Logout(); // Same as this._client.Dispose();
 
-#if UserAuth
+//Uncomment to Allow Insecure Login
+//Make sure that you are aware of the risks of setting this ENV. https://git.io/JU5mt
+/*
 			var userPass = this.GetUsernameAndPassword();
 			// Are all usernames forced lower? I could have sworn i registered with captials >:|
 			this._client = new Vndb(userPass.Item1.ToLower(), userPass.Item2)
@@ -65,7 +67,8 @@ namespace VndbConsole
 //			await this.SetWishlistAsync();
 
 			this._client.Logout(); // Not the same as this._client.Dispose();, it also immediately unsets the password.
-#endif
+*/
+
 
 			Boolean doRaw;
 			while (!Boolean.TryParse(this.GetUserInput("Try Raw Input (True / False): "), out doRaw)) ;
@@ -666,7 +669,10 @@ namespace VndbConsole
 			return input;
 		}
 
-#if UserAuth
+
+//Uncomment to Allow Insecure Login
+//Make sure that you are aware of the risks of setting this ENV. https://git.io/JU5mt
+/*
 		private Tuple<String, SecureString> GetUsernameAndPassword()
 		{
 			var username = this.GetUserInput("Vndb Username: ");
@@ -700,7 +706,8 @@ namespace VndbConsole
 			Console.WriteLine();
 			return new Tuple<String, SecureString>(username, password);
 		}
-#endif
+*/
+
 
 		private void HandleError(IVndbError error)
 		{

--- a/VndbConsoleCore/VndbConsoleCore.csproj
+++ b/VndbConsoleCore/VndbConsoleCore.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/VndbSharp/Json/Converters/SecureStringConverter.cs
+++ b/VndbSharp/Json/Converters/SecureStringConverter.cs
@@ -10,7 +10,7 @@ namespace VndbSharp.Json.Converters
 	{
 		public override void WriteJson(JsonWriter writer, Object value, JsonSerializer serializer)
 		{
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(true))
 			{
 				var unmanagedString = IntPtr.Zero;
 				try

--- a/VndbSharp/Json/VndbContractResolver.cs
+++ b/VndbSharp/Json/VndbContractResolver.cs
@@ -24,10 +24,7 @@ namespace VndbSharp.Json
 			this.CustomConverters = new JsonConverter[]
 			{
 				new SimpleDateConverter(),
-				new DurationToDateTimeOffsetConverter(), 
-#if UserAuth 
-				new SecureStringConverter(),
-#endif
+				new DurationToDateTimeOffsetConverter(),
 				new ArrayOfArraysConverter<CharacterVisualNovelMetadata>(),
 				new ArrayOfArraysConverter<TraitMetadata>(),
 				new ArrayOfArraysConverter<TagMetadata>(),
@@ -40,6 +37,11 @@ namespace VndbSharp.Json
 				new GenericEnumConverter<Voiced>(), 
 				new GenericEnumConverter<Animated>(), 
 			};
+			if (Vndb.AllowInsecure())
+			{
+				this.CustomConverters = this.CustomConverters.Concat(new JsonConverter[] {new SecureStringConverter()})
+					.ToArray();
+			}
 		}
 
 		protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)

--- a/VndbSharp/Json/VndbContractResolver.cs
+++ b/VndbSharp/Json/VndbContractResolver.cs
@@ -37,7 +37,7 @@ namespace VndbSharp.Json
 				new GenericEnumConverter<Voiced>(), 
 				new GenericEnumConverter<Animated>(), 
 			};
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(false))
 			{
 				this.CustomConverters = this.CustomConverters.Concat(new JsonConverter[] {new SecureStringConverter()})
 					.ToArray();

--- a/VndbSharp/Models/Login.cs
+++ b/VndbSharp/Models/Login.cs
@@ -16,7 +16,7 @@ namespace VndbSharp.Models
 
 		public Login(String username, SecureString password) : this()
 		{
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(true))
 			{
 				this.Username = username;
 				this.Password = password;

--- a/VndbSharp/Models/Login.cs
+++ b/VndbSharp/Models/Login.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-#if UserAuth
+
 using System.Security;
-#endif
+
 using Newtonsoft.Json;
 
 namespace VndbSharp.Models
@@ -14,12 +14,13 @@ namespace VndbSharp.Models
 			this.ClientVersion = VndbUtils.ClientVersion;
 		}
 
-#if UserAuth
-		public Login(String username, SecureString password)
-			: this()
+		public Login(String username, SecureString password) : this()
 		{
-			this.Username = username;
-			this.Password = password;
+			if (Vndb.AllowInsecure())
+			{
+				this.Username = username;
+				this.Password = password;
+			}
 		}
 
 		[JsonProperty("password")]
@@ -27,7 +28,7 @@ namespace VndbSharp.Models
 
 		[JsonProperty("username")]
 		public String Username { get; set; }
-#endif
+
 
 		[JsonProperty("protocol")]
 		public UInt32 ProtocolVersion = 1;

--- a/VndbSharp/Vndb.Helpers.cs
+++ b/VndbSharp/Vndb.Helpers.cs
@@ -251,7 +251,7 @@ namespace VndbSharp
 		{
 			// Ensure we're logged in and authenticated
 
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(false))
 			{
 				if (!await this.LoginAsync().ConfigureAwait(false) && this.IsUserAuthenticated)
 					return false;
@@ -413,7 +413,7 @@ namespace VndbSharp
 		/// </summary>
 		public void Logout()
 		{
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(false))
 			{
 				this.Password?.Dispose();
 			}
@@ -454,7 +454,7 @@ namespace VndbSharp
 
 			// Create a login class that can have an optional Username / Password
 			Login login;
-			if (Vndb.AllowInsecure())
+			if (Vndb.AllowInsecure(false))
 			{
 				login = new Login(this.Username, this.Password);
 			}

--- a/VndbSharp/Vndb.Helpers.cs
+++ b/VndbSharp/Vndb.Helpers.cs
@@ -250,13 +250,18 @@ namespace VndbSharp
 		protected async Task<Boolean> SendSetRequestInternalAsync(String method, UInt32 id, Object data, Boolean includeNulls = false)
 		{
 			// Ensure we're logged in and authenticated
-#if UserAuth
-			
-			if (!await this.LoginAsync().ConfigureAwait(false) && this.IsUserAuthenticated)
-#else
-			if (!await this.LoginAsync().ConfigureAwait(false))
-#endif
-				return false;
+
+			if (Vndb.AllowInsecure())
+			{
+				if (!await this.LoginAsync().ConfigureAwait(false) && this.IsUserAuthenticated)
+					return false;
+			}
+			else
+			{
+				if (!await this.LoginAsync().ConfigureAwait(false))
+					return false;
+			}
+
 
 			// For logging
 			var requestData = this.FormatRequest($"{method} {id}", data, includeNulls);

--- a/VndbSharp/Vndb.cs
+++ b/VndbSharp/Vndb.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
 
@@ -33,7 +34,7 @@ namespace VndbSharp
 
 		public Vndb(String username, SecureString password)
 		{
-			if (AllowInsecure())
+			if (AllowInsecure(true))
 			{
 				this.UseTls = true;
 				this.Username = username;
@@ -95,23 +96,33 @@ namespace VndbSharp
 		/// Checks for the environment variable 'ALLOW_UNSECURE_SECURESTRING'
 		/// If it is found, allows using the insecure SecureString
 		/// </summary>
+		/// <param name="throwOnFail">Should the program throw an error if Insecure is disallowed</param>
 		/// <returns></returns>
-		public static bool AllowInsecure()
+		public static Boolean AllowInsecure(Boolean throwOnFail)
 		{
 			var value = Environment.GetEnvironmentVariable("ALLOW_UNSECURE_SECURESTRING");
 			if (!String.IsNullOrEmpty(value))
 			{
-#warning VndbSharp Unsecure SecureStrings are allowed. Make sure that you are aware of the risks of setting this ENV. https://git.io/JU5mt
+				Trace.TraceWarning("VndbSharp Unsecure SecureStrings are allowed. Make sure that you are aware of the risks of setting this ENV. https://git.io/JU5mt");
 				return true;
 			}
 			else
 			{
-				string notice =
+				var notice =
 					"SecureString is not secure on non-Windows OSes when using .Net Core, or at all in Mono." +
 					"By setting the 'ALLOW_UNSECURE_SECURESTRING' environment variable, and/or this warning, you acknowledge the risks and will not make PRs or Issues regarding this unless the situation in .Net Core / Mono changes. \n" +
 					"To read more above the above messages, check out https://github.com/Nikey646/VndbSharp/wiki/Mono-and-.Net-Core#securestring--username--password-logins \n" +
 					"If that link is down, do some research on SecureString implementations in .Net Core, to see if they encrypt the data in memory on Unix.";
-				throw new NotSupportedException(notice);
+
+				if (throwOnFail == true)
+				{
+					throw new NotSupportedException(notice);
+				}
+				else
+				{
+					return false;
+				}
+				
 			}
 		}
 
@@ -195,7 +206,7 @@ namespace VndbSharp
 		{
 			get
 			{
-				if (AllowInsecure())
+				if (AllowInsecure(false))
 				{
 					return this.Password != null && this.Stream != null;
 				}

--- a/VndbSharp/VndbSharp.csproj
+++ b/VndbSharp/VndbSharp.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="System.Security.SecureString" Version="4.3.0" Condition="$(DefineConstants.Contains('UserAuth'))" />
+		<PackageReference Include="System.Security.SecureString" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
 		<PackageReference Include="System.Net.Http" Version="4.3.2" />

--- a/VndbSharp/VndbSharp.csproj
+++ b/VndbSharp/VndbSharp.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup Label="Configuration">
-		<DocumentationFile>bin\Debug\netstandard1.3\VndbSharp.xml</DocumentationFile>
+		<DocumentationFile>bin\Debug\netstandard2.0\VndbSharp.xml</DocumentationFile>
 	</PropertyGroup>
 	<PropertyGroup>
-		<TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+		<TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Version>1.1.0</Version>
 		<Description>A .Net Library to communicate with the Vndb API</Description>
@@ -21,13 +21,13 @@
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="System.Security.SecureString" Version="4.3.0" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
 		<PackageReference Include="System.Net.Http" Version="4.3.2" />
 		<PackageReference Include="System.Net.Security" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
 		<PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
+	<ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
 		<Reference Include="System" />
 		<Reference Include="System.Net.Http" />
 		<Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Replaced UserAuth compiler directives in favor of Environmental variables. This way, the user can set if they want to use the insecure SecureString in their project using the nuget package, instead of trying to compile the project from source.

Right now, it just looks for the environmental variable key ```ALLOW_UNSECURE_SECURESTRING```, but I can also have it look for that, AND what value is inside it, if need be.

.Net Standard was updated from 1.3 to 2.0, so that ```Trace``` could be used.

The method ```AllowInsecure``` allows for throwing an error if it's false, so any attempts to login without the ENV set will throw an error. However, parts where it was just doing a check if UserAuth was on before now won't generate an error.

This should allow the developers using the nuget package to decide if they want the risks associated with using SecureString, without having it enabled by default. It's now an opt in value that the programmers have to manually create in order to use it.
